### PR TITLE
Add tox

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -43,14 +43,11 @@ jobs:
           path: dist/
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
-      - name: Install the package
+          python-version: "3.10 - 3.12"
+      - name: Test with tox
         run: |
-          python -m pip install dist/pyisyntax-*.tar.gz
-      - name: Test with pytest
-        run: |
-          python -m pip install pytest==8.0.0 pytest-mock==3.12.0
-          pytest tests/
+          python -m pip install tox
+          tox --installpkg dist/pyisyntax-*.tar.gz
 
   build-wheels:
     name: Build ${{ matrix.platform_tag }} wheels
@@ -83,8 +80,8 @@ jobs:
           CIBW_BUILD_FRONTEND: build
           CIBW_BUILD: cp310-${{ matrix.platform_tag }}
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.10'
-          CIBW_TEST_REQUIRES: pytest==8.0.0 pytest-mock==3.12.0
-          CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_TEST_REQUIRES: tox
+          CIBW_TEST_COMMAND: "tox -e py310,py311,py312 -c {package}/pyproject.toml --installpkg {wheel}"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ core
 /tests/data/testslide.isyntax
 /build/
 /dist/
+/.tox/
 *.egg-info/
 .eggs/
 *.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ dev = [
   "pytest",
   "pytest-mock",
   "ruff==0.2.1",
+  "tox>=4.0",
   "twine",
+  "typing_extensions",
 ]
 
 [tool.conda-lock]
@@ -59,6 +61,31 @@ pydocstyle.convention = "google"
 
 [tool.pyright]
 typeCheckingMode = "standard"
+
+[tool.tox]
+legacy_tox_ini = """
+[tox]
+min_version = 4.0
+env_list = lint, type, py{310,311,312}
+
+[testenv]
+deps =
+  pytest
+  pytest-mock
+commands = pytest {posargs:tests}
+
+[testenv:lint]
+skip_install = true
+deps =
+  ruff==0.2.1
+commands = ruff check {posargs:.}
+
+[testenv:type]
+deps =
+  pyright
+  typing_extensions
+commands = pyright {posargs:isyntax}
+"""
 
 [tool.setuptools.packages.find]
 include = ["isyntax", "isyntax.*"]


### PR DESCRIPTION
Use tox to:
- Test with multiple Python versions now that cibuildwheel is no longer building per-Python wheels
- Lint
- Check types