### PR TITLE
Nest _pyisyntax under pyisyntax

### DIFF
--- a/isyntax/lowlevel/io_management.py
+++ b/isyntax/lowlevel/io_management.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from io import BufferedIOBase, RawIOBase
 from typing import Generic, NewType, TypeVar
 
-from _pyisyntax import ffi, lib
+from pyisyntax._pyisyntax import ffi, lib
 
 VoidPtr = NewType("VoidPtr", object)
 T = TypeVar("T")

--- a/isyntax/lowlevel/libisyntax.py
+++ b/isyntax/lowlevel/libisyntax.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, NewType
 
-from _pyisyntax import ffi, lib
+from pyisyntax._pyisyntax import ffi, lib
 
 from isyntax.lowlevel.io_management import init_python_io_hooks, register_io
 

--- a/isyntax_build/builder.py
+++ b/isyntax_build/builder.py
@@ -43,7 +43,7 @@ def create_ffibuilder() -> FFI:
         libraries = []
 
     ffibuilder.set_source(
-        "_pyisyntax",
+        "pyisyntax._pyisyntax",
         resources.read_text(isyntax_build, "pyisyntax.c"),
         sources=paths_to_strings(
             libisyntax_src/"libisyntax.c",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ env_list = lint, type, py{310,311,312}
 deps =
   pytest
   pytest-mock
-commands = pytest {posargs:tests}
+commands = pytest --import-mode=importlib {posargs:tests}
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
Move the low-level built library under the top-level `pyisyntax` module.