### PR TITLE
Support building on aarch64 Linux

### DIFF
--- a/isyntax_build/builder.py
+++ b/isyntax_build/builder.py
@@ -1,4 +1,5 @@
 import os
+import platform
 from importlib import resources
 from pathlib import Path
 
@@ -41,6 +42,19 @@ def create_ffibuilder() -> FFI:
         platform_sources = []
         extra_compile_args = []
         libraries = []
+        # The vendored libisyntax guards its SIMD/atomics on x86-centric macros
+        # that GCC does not define on aarch64 Linux, so the arm build otherwise
+        # fails to compile / links x86-only intrinsics. Select the correct paths:
+        #   __ARM_NEON__ -> intrinsics.h includes <arm_neon.h> for the NEON code
+        #   __arm64      -> ltalloc spin-wait uses sched_yield, not x86 `pause`
+        #   the last two map x86-only bit intrinsics onto portable GCC builtins
+        if platform.machine() in ("aarch64", "arm64"):
+            extra_compile_args += [
+                "-D__ARM_NEON__=1",
+                "-D__arm64=1",
+                "-D_bit_scan_forward=__builtin_ctz",
+                "-D_popcnt32=__builtin_popcount",
+            ]
 
     ffibuilder.set_source(
         "isyntax._pyisyntax",


### PR DESCRIPTION
## Summary

Enables building `pyisyntax` from source on **aarch64 Linux** (e.g. arm64 servers / NVIDIA Jetson/Grace). Today there is no arm64 Linux wheel, and building from sdist fails on that platform.

## Problem

The vendored libisyntax guards its SIMD and atomics on x86-centric macros that GCC does **not** define on aarch64 Linux, so the arm build breaks in two ways:

1. **Compile error** — `isyntax.c` uses NEON code under `#if defined(__ARM_NEON)` (which GCC *does* define on aarch64), but `intrinsics.h` only includes `<arm_neon.h>` under `defined(__ARM_NEON__)` (trailing underscores, which GCC does **not** define). Result: `unknown type name 'uint32x4_t'`.
2. **Link/assemble errors** — the generic Linux path uses the x86 `pause` instruction (via ltalloc's `#elif defined(__arm64)`, an Apple/clang macro not defined by GCC) and the x86-only intrinsics `_bit_scan_forward` / `_popcnt32`.

## Fix

`isyntax_build/builder.py` supplies the compile flags that select libisyntax's existing non-x86 code paths, gated to `platform.machine() in ("aarch64", "arm64")` so other platforms are untouched:

- `-D__ARM_NEON__=1` — makes `intrinsics.h` include `<arm_neon.h>` for the NEON code
- `-D__arm64=1` — routes ltalloc's spin-wait to `sched_yield` instead of x86 `pause`
- `-D_bit_scan_forward=__builtin_ctz`, `-D_popcnt32=__builtin_popcount` — map the x86-only bit intrinsics onto portable GCC builtins

(These compensate for macro-spelling assumptions in libisyntax; the cleanest long-term home is fixing those guards in libisyntax itself, but supplying the flags here makes `pyisyntax` build on arm64 today without touching the submodule.)

## Testing

Built on aarch64 Linux (Ubuntu 24.04, GCC 13) and ran a full conversion of a real ~2.7-gigapixel brightfield `.isyntax` slide to a pyramided output — pixel output verified correct.

## Related (separate, not in this PR)

While testing I hit a second arm64-relevant issue that lives in **libisyntax**, not this repo: `libisyntax_tile_read` / `libisyntax_read_region` dereference the thread-local `local_thread_memory` arena, which is only initialized for the thread that opens a slide and libisyntax's own worker threads. Reading from any other thread (e.g. a host app's reader-pool thread) NULL-derefs and segfaults. A lazy `if (local_thread_memory == NULL) init_thread_memory(0, &global_system_info);` guard at those entry points fixes it. Happy to send that to amspath/libisyntax as a follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)